### PR TITLE
fix(auto): clear stale reconciliation metadata on attach and scope invalid reconcile errors

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -96,10 +96,13 @@ class AutoPipeline:
         self._save(state)
 
         if self.reconcile_run and state.phase == AutoPhase.COMPLETE:
-            reconciled = self._reconcile_run_if_requested(state)
+            reconciled, transient_blocker = self._reconcile_run_if_requested(state)
             if reconciled is not None:
                 self._save(state)
-                blocker = state.last_error if reconciled is False else None
+                if reconciled is False:
+                    blocker = transient_blocker or state.last_error
+                else:
+                    blocker = None
                 status_override = "blocked" if reconciled is False else None
                 return self._result(
                     state,
@@ -285,10 +288,11 @@ class AutoPipeline:
             if attached is not None:
                 self._save(state)
                 return self._result(state, ledger, review=review)
-            reconciled = self._reconcile_run_if_requested(state)
+            reconciled, transient_blocker = self._reconcile_run_if_requested(state)
             if reconciled is not None:
                 self._save(state)
-                return self._result(state, ledger, review=review, blocker=state.last_error)
+                blocker = transient_blocker or state.last_error
+                return self._result(state, ledger, review=review, blocker=blocker)
             if any((state.job_id, state.execution_id, state.run_session_id)):
                 state.run_handoff_status = "started"
                 state.run_handoff_guidance = None
@@ -473,12 +477,32 @@ class AutoPipeline:
             "Attached an externally verified execution handle to this auto session; "
             "resume will use the attached handle and will not start a duplicate run."
         )
+        # Successful attach supersedes any prior reconciliation outcome on the
+        # same unknown handoff, so clear stale reconciliation metadata to avoid
+        # surfacing contradictory state (attached + previous reconciliation failure).
+        state.run_reconciliation_status = None
+        state.run_reconciliation_source = None
+        state.run_reconciled_at = None
         state.transition(AutoPhase.COMPLETE, "attached existing execution handle")
         return True
 
-    def _reconcile_run_if_requested(self, state: AutoPipelineState) -> bool | None:
+    def _reconcile_run_if_requested(
+        self, state: AutoPipelineState
+    ) -> tuple[bool | None, str | None]:
+        """Run the generic reconciliation contract.
+
+        Returns ``(outcome, transient_blocker)``:
+
+        - ``outcome`` is ``None`` when reconcile was not requested, ``True`` for
+          a successful reconciliation, and ``False`` when the request fails.
+        - ``transient_blocker`` carries an invocation-only error message that
+          must be surfaced to the caller for the current call only. It is used
+          for failure paths (notably invalid-context against a terminal complete
+          session) where mutating ``state.last_error`` durably would leak the
+          error into every later plain ``--resume``/``--status`` response.
+        """
         if not self.reconcile_run:
-            return None
+            return None, None
         if state.run_handoff_status == "attached" and state.attached_run_handle:
             state.run_reconciliation_status = "attached"
             state.run_reconciliation_source = _optional_str(self.reconcile_source) or "attached_run"
@@ -496,7 +520,7 @@ class AutoPipeline:
                 state.transition(
                     AutoPhase.COMPLETE, "reconciled existing attached execution handle"
                 )
-            return True
+            return True, None
         if not state.run_start_attempted or state.run_handoff_status not in {
             "unknown_no_handle",
             "unknown_timeout",
@@ -510,12 +534,16 @@ class AutoPipeline:
             state.run_reconciled_at = utc_now_iso()
             state.run_handoff_guidance = msg
             if state.phase == AutoPhase.COMPLETE:
+                # Keep the terminal phase intact and avoid corrupting durable
+                # state.last_error: future plain --resume/--status calls must
+                # not report this per-invocation misuse as a steady-state
+                # blocker. The message is returned as a transient blocker so
+                # the current call still surfaces it via the result.
                 state.last_tool_name = "run_starter"
-                state.last_error = msg
                 state.mark_progress(msg, tool_name="run_starter")
-            else:
-                state.mark_blocked(msg, tool_name="run_starter")
-            return False
+                return False, msg
+            state.mark_blocked(msg, tool_name="run_starter")
+            return False, None
         state.run_reconciliation_status = "unsupported"
         state.run_reconciliation_source = _optional_str(self.reconcile_source) or "generic"
         state.run_reconciled_at = utc_now_iso()
@@ -526,7 +554,7 @@ class AutoPipeline:
             "reconciler that returns attached, not_found, ambiguous, or unsupported."
         )
         state.mark_blocked(state.run_handoff_guidance, tool_name="run_starter")
-        return False
+        return False, None
 
     def _save(self, state: AutoPipelineState) -> None:
         if self.store is not None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2417,3 +2417,117 @@ async def test_complete_session_invalid_reconcile_reports_blocked_result(tmp_pat
     assert result.run_reconciliation_status == "invalid_context"
     assert result.run_reconciliation_source == "generic"
     assert "unknown run handoff" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_attach_clears_stale_reconciliation_metadata(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    async def run_seed(seed: Seed) -> dict[str, str | None]:  # noqa: ARG001
+        raise AssertionError("attach must not start another run")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.run_start_attempted = True
+    state.run_handoff_status = "unknown_no_handle"
+    state.mark_blocked("Run starter returned no tracking handle", tool_name="run_starter")
+    # Prior --reconcile-run on the same unknown handoff recorded an unsupported
+    # reconciliation outcome. A subsequent successful attach must clear those
+    # fields so callers do not see contradictory state.
+    state.run_reconciliation_status = "unsupported"
+    state.run_reconciliation_source = "generic"
+    state.run_reconciled_at = "2026-05-07T00:00:00+00:00"
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        attach_execution_id="exec_existing",
+        attach_source="operator",
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "attached"
+    assert result.attached_run_handle == "exec_existing"
+    assert result.run_reconciliation_status is None
+    assert result.run_reconciliation_source is None
+    assert result.run_reconciled_at is None
+    assert state.run_reconciliation_status is None
+    assert state.run_reconciliation_source is None
+    assert state.run_reconciled_at is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_reconcile_on_complete_does_not_poison_future_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume should not regenerate seed")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "already complete without run handoff")
+    assert state.last_error is None
+
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+
+    invalid_pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+        reconcile_run=True,
+    )
+    invalid_result = await invalid_pipeline.run(state)
+
+    assert invalid_result.status == "blocked"
+    assert invalid_result.run_reconciliation_status == "invalid_context"
+    assert "unknown run handoff" in (invalid_result.blocker or "")
+    # Per-invocation misuse must not corrupt the durable terminal-complete state:
+    # last_error stays clean so subsequent plain --resume/--status do not
+    # report a steady-state blocker.
+    assert state.phase == AutoPhase.COMPLETE
+    assert state.last_error is None
+
+    plain_pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=None,
+        store=AutoStore(tmp_path),
+    )
+    plain_result = await plain_pipeline.run(state)
+
+    assert plain_result.status == "complete"
+    assert plain_result.blocker is None
+    assert state.last_error is None


### PR DESCRIPTION
Stacked on PR Q00/ouroboros#685 (`feat/677-auto-reconcile-run-handoff`). Addresses the two non-blocking warnings from the latest `ouroboros-agent` review on that PR, so #685 can land without leaving known follow-up cleanup in #677's `Closes` scope.

## Summary
- Successful `--attach-execution/--attach-job/--attach-session` now clears any prior `run_reconciliation_status / run_reconciliation_source / run_reconciled_at`. Without this, attaching after an earlier `--reconcile-run` left contradictory metadata (`run_handoff_status="attached"` together with a stale `unsupported`/`invalid_context` reconciliation result).
- Invalid `--reconcile-run` against a terminal complete session (one that was never in an unknown handoff) no longer mutates durable `state.last_error`. Previously, the normal complete-path return forwarded `state.last_error` as the public blocker, so one mistaken reconcile permanently made later plain `--resume`/`--status` responses report a steady-state blocker on an otherwise clean complete session.
- The current invocation still surfaces the error via `result.blocker`/`status_override="blocked"` by routing the message through a new transient-blocker return value from `_reconcile_run_if_requested` instead of writing it to durable state.

## Discussion / implementation notes
- `_reconcile_run_if_requested` now returns `tuple[bool | None, str | None]`. The second element is an invocation-only error that callers forward as the per-call blocker without persisting it on the session. Both call sites in `pipeline.py` were updated.
- Existing `invalid_context` regression tests (`test_pipeline_marks_reconcile_invalid_context_separately`, `test_complete_session_invalid_reconcile_reports_blocked_result`) still pass — the public blocker contract is unchanged.

## Validation
- ``UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_interview_pipeline.py -q`` → **78 passed** (76 prior + 2 new regression tests)
- ``UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/auto/test_surface.py -q`` → 52 passed
- ``UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/unit/cli/test_auto_command.py -q`` → 5 passed
- ``UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src tests`` → All checks passed
- ``UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check src/ouroboros/auto/pipeline.py tests/unit/auto/test_interview_pipeline.py`` → 2 files already formatted

## New regression tests
- `test_pipeline_attach_clears_stale_reconciliation_metadata` — prior `unsupported` reconciliation followed by successful attach asserts all `run_reconciliation_*` fields are cleared on both the result and the persisted state.
- `test_invalid_reconcile_on_complete_does_not_poison_future_resume` — invalid reconcile on a terminal complete session reports `blocked` for the current call, then a subsequent plain resume on the same state returns `complete` with no blocker and `state.last_error is None`.

Refs #677
Stacks on Q00/ouroboros#685