### PR TITLE
feat(auto): route AutoAnswerer through active DomainProfile (#809 P3, PR 4/6)

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -6,8 +6,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
 import re
+from typing import TYPE_CHECKING
 
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+
+if TYPE_CHECKING:
+    from ouroboros.auto.domain_profile import DomainProfile
 
 
 class AutoAnswerSource(StrEnum):
@@ -114,7 +118,27 @@ class AutoAnswerer:
 
     This class is deterministic and performs no unbounded repository or network
     exploration.  Later integrations may pass bounded repo facts into it.
+
+    Parameters
+    ----------
+    active_profile:
+        Optional domain profile.  When supplied, intent classification,
+        vague-term detection, and verifiable-predicate lookup are delegated
+        to the profile.  When ``None`` (the default) the existing hardcoded
+        coding-domain logic runs verbatim — this is the **safety hatch** that
+        preserves backward compatibility for callers that do not activate a
+        profile.
     """
+
+    # -- DUAL-PATH MARKER (PR-4): the safety hatch lives in __init__ ---------
+    # With ``active_profile=None`` every method below falls through to the
+    # original hardcoded coding-domain paths.  With a profile the three hooks
+    # (intent classification, vague-term check, predicate repair) delegate to
+    # the profile's callbacks.  No hardcoded path is removed.
+    # -------------------------------------------------------------------------
+
+    def __init__(self, active_profile: DomainProfile | None = None) -> None:
+        self.active_profile = active_profile
 
     def answer(
         self,
@@ -125,7 +149,34 @@ class AutoAnswerer:
         """Answer ``question`` using a conservative policy and optional bounded facts."""
         context = context or AutoAnswerContext()
         lowered = _normalize_question(question)
-        intents = _classify_question_intents(question)
+
+        # -- DUAL-PATH HOOK 1: intent classification --------------------------
+        # When a domain profile is active, ask its classifier first.  The
+        # profile returns a single canonical label string (e.g.
+        # ``"verification"``) or None.  We map the label back to a
+        # QuestionIntent so the downstream routing logic is unchanged.  If the
+        # profile cannot classify (None) OR no profile is active, fall through
+        # to the hardcoded ``_classify_question_intents`` path.
+        if self.active_profile is not None:
+            profile_label = self.active_profile.intent_classifier.classify(question)
+            if profile_label is not None:
+                intents = _intents_from_profile_label(profile_label)
+            else:
+                intents = _classify_question_intents(question)
+            # -- DUAL-PATH HOOK 2: vague-term detection -----------------------
+            # When a profile is active, any term from its ``vague_terms`` set
+            # that appears in the lowered question signals that the AC is
+            # under-specified.  We inject VERIFICATION so the answerer steers
+            # the user toward observable behavior rather than accepting vague
+            # language.  The hardcoded path has no equivalent check (there are
+            # no inline vague-term lists in this file), so this is additive.
+            if any(term in lowered for term in self.active_profile.vague_terms):
+                intents = frozenset(intents | {QuestionIntent.VERIFICATION})
+        else:
+            # Safety hatch: original hardcoded coding-domain classification.
+            intents = _classify_question_intents(question)
+        # ---------------------------------------------------------------------
+
         blocker = _blocker_for(question)
         if blocker is not None:
             return AutoAnswer(
@@ -352,6 +403,24 @@ class AutoAnswerer:
         )
 
     def _verification_answer(self, question: str) -> AutoAnswer:  # noqa: ARG002
+        # -- DUAL-PATH HOOK 3: verifiable-predicate repair --------------------
+        # When a profile is active, iterate its ``verifiable_predicates`` in
+        # order and use the first one whose ``matches`` returns True against the
+        # question text.  The predicate's ``repair_template`` replaces the
+        # hardcoded "exit code 0 and stdout" AC text so domain-specific
+        # verification language appears in the Seed instead of the coding
+        # default.  When no predicate matches (or no profile is active), the
+        # original hardcoded coding-domain text is used verbatim — safety hatch.
+        if self.active_profile is not None:
+            matched = self.active_profile.find_verifiable_predicate(question)
+            if matched is not None:
+                ac_value = matched.repair_template(question)
+            else:
+                ac_value = "A command-level check returns exit code 0 and stdout contains stable output or writes a reproducible artifact for each acceptance criterion."
+        else:
+            # Safety hatch: original hardcoded coding-domain AC text.
+            ac_value = "A command-level check returns exit code 0 and stdout contains stable output or writes a reproducible artifact for each acceptance criterion."
+        # ---------------------------------------------------------------------
         value = "Success must be verified with observable behavior: commands or tests should produce stable output, non-zero failures for invalid input, and reproducible artifacts where applicable."
         updates = [
             (
@@ -369,7 +438,7 @@ class AutoAnswerer:
                 "acceptance_criteria",
                 LedgerEntry(
                     key="acceptance.observable_behavior",
-                    value="A command-level check returns exit code 0 and stdout contains stable output or writes a reproducible artifact for each acceptance criterion.",
+                    value=ac_value,
                     source=LedgerSource.CONSERVATIVE_DEFAULT,
                     confidence=0.82,
                     status=LedgerStatus.DEFAULTED,
@@ -806,6 +875,37 @@ def _classify_question_intents(question: str) -> frozenset[QuestionIntent]:
         intents.add(QuestionIntent.PRODUCT_BEHAVIOR)
 
     return frozenset(intents)
+
+
+# -- DUAL-PATH HELPER (PR-4): map profile label → QuestionIntent set ---------
+# Profile classifiers emit canonical string labels (e.g. ``"verification"``).
+# This helper translates a single label back into a frozenset so the existing
+# intent-routing table below works without modification.  Labels that do not
+# map to a known QuestionIntent return an empty frozenset, causing the answerer
+# to fall through to ``_default_answer`` — the same behavior as an empty
+# ``_classify_question_intents`` result.
+_PROFILE_LABEL_TO_INTENT: dict[str, QuestionIntent] = {
+    "non_goals": QuestionIntent.NON_GOALS,
+    "verification": QuestionIntent.VERIFICATION,
+    "acceptance_criteria": QuestionIntent.ACCEPTANCE_CRITERIA,
+    "actor_io": QuestionIntent.ACTOR_IO,
+    "runtime_context": QuestionIntent.RUNTIME_CONTEXT,
+    "product_behavior": QuestionIntent.PRODUCT_BEHAVIOR,
+}
+
+
+def _intents_from_profile_label(label: str) -> frozenset[QuestionIntent]:
+    """Convert a single profile-classifier label to a ``frozenset[QuestionIntent]``.
+
+    Returns an empty frozenset for unknown labels so the answerer falls back to
+    ``_default_answer`` — the same behavior as ``_classify_question_intents``
+    returning no intents.
+    """
+    intent = _PROFILE_LABEL_TO_INTENT.get(label)
+    return frozenset({intent}) if intent is not None else frozenset()
+
+
+# ----------------------------------------------------------------------------
 
 
 # Regex for cues composed only of plain ASCII letters (a–z), spaces, hyphens,

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -11,7 +11,9 @@ import time
 from typing import Any, Protocol
 
 from ouroboros.auto.adapters import EvaluateResult, LateralResult
+from ouroboros.auto.answerer import AutoAnswerer
 from ouroboros.auto.blocker_attribution import record_authoring_backend
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.grading import GradeGate, deterministic_floor
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.lateral_routing import select_persona_for_qa_failure
@@ -241,6 +243,16 @@ class AutoPipeline:
             state.complete_product = True
         elif state.complete_product and not self.complete_product:
             self.complete_product = True
+        # Q00/ouroboros#809 P3 PR-4: thread active domain profile into the
+        # answerer.  Resolve name → DomainProfile via DEFAULT_REGISTRY and
+        # inject it so intent classification, vague-term detection, and
+        # verifiable-predicate repair all delegate to the profile when active.
+        # When the name is None or not found, ``active_profile=None`` is set
+        # which preserves the hardcoded coding-domain safety hatch verbatim.
+        # Guard with getattr so test doubles that omit ``answerer`` are skipped.
+        _answerer = getattr(self.interview_driver, "answerer", None)
+        if _answerer is not None:
+            _apply_active_profile(state, _answerer)
         # Validate the persisted Seed artifact BEFORE any other path can
         # trigger a state-validating save. ``AutoStore.save`` re-validates the
         # full state, so a malformed ``seed_artifact`` would otherwise raise a
@@ -2153,3 +2165,24 @@ def _artifact_text(value: object) -> str | None:
     and silently transition to COMPLETE.
     """
     return value if isinstance(value, str) else None
+
+
+# -- PR-4 helper: thread domain profile into answerer -----------------------
+
+
+def _apply_active_profile(state: AutoPipelineState, answerer: AutoAnswerer) -> None:
+    """Resolve ``state.active_domain_profile_name`` and inject into ``answerer``.
+
+    When the name is ``None`` or not found in ``DEFAULT_REGISTRY``, sets
+    ``answerer.active_profile = None`` so the hardcoded safety hatch runs.
+    This is intentionally a no-op for sessions that never activated a profile.
+    When ``answerer`` does not have an ``active_profile`` attribute (e.g. a
+    test double), the call is silently skipped.
+    """
+    if not hasattr(answerer, "active_profile"):
+        return
+    name = getattr(state, "active_domain_profile_name", None)
+    if name:
+        answerer.active_profile = DEFAULT_REGISTRY.get(name)
+    else:
+        answerer.active_profile = None

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -301,6 +301,12 @@ class AutoPipelineState:
     # when the operator forgets to re-pass the flag. Defaults to False so
     # legacy state files load unchanged.
     complete_product: bool = False
+    # Q00/ouroboros#809 P3 PR-4: active domain profile name.  Set by the CLI
+    # activation layer (PR-3) to a name registered in ``DEFAULT_REGISTRY``.
+    # ``None`` means no profile is active — the answerer falls back to the
+    # hardcoded coding-domain paths.  Defaults to ``None`` so legacy state
+    # files load unchanged.
+    active_domain_profile_name: str | None = None
     ledger: dict[str, Any] = field(default_factory=dict)
     last_grade: str | None = None
     findings: list[dict[str, Any]] = field(default_factory=list)

--- a/tests/unit/auto/test_answerer_via_domain_profile.py
+++ b/tests/unit/auto/test_answerer_via_domain_profile.py
@@ -1,0 +1,219 @@
+"""Tests for AutoAnswerer domain-profile routing (#809 P3, PR 4/6).
+
+Verifies the dual-path behavior introduced by PR-4:
+- With an active profile, intent classification, vague-term detection, and
+  verifiable-predicate repair all delegate to the profile.
+- Without a profile (``active_profile=None``) the hardcoded coding-domain
+  safety hatch runs verbatim.
+
+All fixtures are tiny inline stubs; CODING_PROFILE is intentionally NOT
+imported because PR-2 may not be merged yet.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.answerer import AutoAnswerer
+from ouroboros.auto.domain_profile import DomainProfile  # noqa: F401
+from ouroboros.auto.ledger import SeedDraftLedger
+
+# ---------------------------------------------------------------------------
+# Inline stubs — no real profile imported
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysVerificationClassifier:
+    """Classifies every question as 'verification'."""
+
+    def classify(self, question: str) -> str | None:
+        return "verification"
+
+    def supported_intents(self) -> frozenset[str]:
+        return frozenset({"verification"})
+
+
+class _NeverClassifier:
+    """Always returns None — no intent recognised."""
+
+    def classify(self, question: str) -> str | None:
+        return None
+
+    def supported_intents(self) -> frozenset[str]:
+        return frozenset()
+
+
+class _ContrastPredicate:
+    """Matches questions mentioning 'contrast'; repair uses WCAG language."""
+
+    code = "wcag_contrast"
+
+    def matches(self, criterion: str) -> bool:
+        return "contrast" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Contrast ratio must be ≥ 4.5:1 for: {criterion}"
+
+
+class _ExitCodePredicate:
+    """Matches questions mentioning 'exit'; repair uses exit-code language."""
+
+    code = "exit_code"
+
+    def matches(self, criterion: str) -> bool:
+        return "exit" in criterion.lower()
+
+    def repair_template(self, criterion: str) -> str:
+        return f"Command must exit 0 for: {criterion}"
+
+
+class _NoopExtractor:
+    def extract(self, cwd):  # type: ignore[override]
+        return {}
+
+
+def _never_detector(cwd):  # type: ignore[override]
+    return 0.0
+
+
+def _make_profile(
+    *,
+    classifier=None,
+    predicates=(),
+    vague_terms=frozenset(),
+    name="test",
+) -> DomainProfile:
+    return DomainProfile(
+        name=name,
+        repo_context_extractor=_NoopExtractor(),
+        verifiable_predicates=tuple(predicates),
+        intent_classifier=classifier or _NeverClassifier(),
+        vague_terms=frozenset(vague_terms),
+        safe_defaults={},
+        detector=_never_detector,
+    )
+
+
+def _ledger() -> SeedDraftLedger:
+    return SeedDraftLedger.from_goal("Build a feature")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyRoutesThroughProfileWhenActive:
+    """Profile classifier is consulted when active_profile is set."""
+
+    def test_classify_routes_through_profile_when_active(self):
+        profile = _make_profile(classifier=_AlwaysVerificationClassifier())
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        # Any question should be routed to _verification_answer via the profile
+        answer = answerer.answer("What runtime do you use?", ledger)
+        # Verification answer has CONSERVATIVE_DEFAULT source
+        assert answer.source.value == "conservative_default"
+        # The answer text mentions verifiable/observable behavior
+        assert "verif" in answer.text.lower() or "observ" in answer.text.lower()
+
+    def test_classify_falls_back_to_hardcoded_when_no_profile(self):
+        answerer = AutoAnswerer(active_profile=None)
+        ledger = _ledger()
+        # A verification question should still be routed via hardcoded path
+        answer = answerer.answer("How should we verify the tests pass?", ledger)
+        assert answer.source.value == "conservative_default"
+        assert "verif" in answer.text.lower() or "observ" in answer.text.lower()
+
+    def test_unknown_intent_returns_default_answer(self):
+        profile = _make_profile(classifier=_NeverClassifier())
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        answer = answerer.answer("Something completely unrelated xyzzy", ledger)
+        # Falls through to _default_answer: generic_default=True
+        assert answer.generic_default is True
+
+
+class TestVagueTermLookupUsesProfile:
+    """Profile vague_terms set is consulted when active_profile is set."""
+
+    def test_vague_term_triggers_verification_route(self):
+        profile = _make_profile(
+            classifier=_NeverClassifier(),  # would return default without vague-term
+            vague_terms={"easy", "clean"},
+        )
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        # "clean" appears in question — should inject VERIFICATION intent
+        answer = answerer.answer("The UI should look clean and easy to use", ledger)
+        # Routed to _verification_answer, not _default_answer
+        assert answer.generic_default is False
+
+    def test_no_vague_term_no_injection(self):
+        profile = _make_profile(
+            classifier=_NeverClassifier(),
+            vague_terms={"easy", "clean"},
+        )
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        answer = answerer.answer("Something completely unrelated xyzzy", ledger)
+        assert answer.generic_default is True
+
+    def test_vague_term_absent_without_profile(self):
+        """Without a profile, vague-term injection never happens."""
+        answerer = AutoAnswerer(active_profile=None)
+        ledger = _ledger()
+        # "clean" alone with no profile should fall to default (not verification)
+        answer = answerer.answer("The code should be clean", ledger)
+        # Hardcoded path: no vague-term logic — routes to default
+        assert answer.generic_default is True
+
+
+class TestVerifiablePredicateIterationPicksFirstMatch:
+    """Profile predicates are iterated and the first match is used."""
+
+    def test_verifiable_predicate_iteration_picks_first_match(self):
+        # _ContrastPredicate matches "contrast", _ExitCodePredicate matches "exit"
+        profile = _make_profile(
+            classifier=_AlwaysVerificationClassifier(),
+            predicates=[_ContrastPredicate(), _ExitCodePredicate()],
+        )
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        # "contrast" question — first predicate matches
+        answer = answerer.answer("Does the UI contrast meet accessibility standards?", ledger)
+        # The AC ledger entry should use the contrast predicate repair_template
+        ac_entries = [
+            entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+        ]
+        assert ac_entries, "Expected an acceptance_criteria ledger entry"
+        assert "4.5:1" in ac_entries[0].value
+
+    def test_second_predicate_used_when_first_does_not_match(self):
+        profile = _make_profile(
+            classifier=_AlwaysVerificationClassifier(),
+            predicates=[_ContrastPredicate(), _ExitCodePredicate()],
+        )
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        # "exit" question — first predicate does NOT match, second does
+        answer = answerer.answer("The command should exit successfully", ledger)
+        ac_entries = [
+            entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+        ]
+        assert ac_entries
+        assert "exit 0" in ac_entries[0].value
+
+    def test_no_predicate_match_uses_hardcoded_fallback(self):
+        profile = _make_profile(
+            classifier=_AlwaysVerificationClassifier(),
+            predicates=[_ContrastPredicate()],  # only contrast predicate
+        )
+        answerer = AutoAnswerer(active_profile=profile)
+        ledger = _ledger()
+        # No predicate matches "runtime behavior" question
+        answer = answerer.answer("What runtime behavior verifies the feature?", ledger)
+        ac_entries = [
+            entry for section, entry in answer.ledger_updates if section == "acceptance_criteria"
+        ]
+        assert ac_entries
+        # Falls back to hardcoded "exit code 0" text
+        assert "exit code 0" in ac_entries[0].value


### PR DESCRIPTION
## Summary

- Introduces **dual-path routing** in `AutoAnswerer`: when `active_profile` is set, intent classification, vague-term detection, and verifiable-predicate AC repair delegate to the profile; when `None`, the hardcoded coding-domain logic runs verbatim (safety hatch).
- Threads the profile from `AutoPipelineState.active_domain_profile_name` → `DEFAULT_REGISTRY.get()` → `AutoAnswerer.active_profile` via a new `_apply_active_profile()` helper in `pipeline.py`.
- Adds 9 new unit tests using inline stubs (no `CODING_PROFILE` dependency — safe even if PR-2 is not yet merged).

## Dual-path comment markers added

| File | Marker |
|------|--------|
| `answerer.py` docstring | `# -- DUAL-PATH MARKER (PR-4)` — explains the safety hatch |
| `answer()` method | `# -- DUAL-PATH HOOK 1: intent classification` |
| `answer()` method | `# -- DUAL-PATH HOOK 2: vague-term detection` |
| `_verification_answer()` | `# -- DUAL-PATH HOOK 3: verifiable-predicate repair` |
| `pipeline.py` helper | `# -- PR-4 helper: thread domain profile into answerer` |

## Files changed

- `src/ouroboros/auto/answerer.py` — `__init__`, three routing hooks, `_intents_from_profile_label`, `_PROFILE_LABEL_TO_INTENT`
- `src/ouroboros/auto/state.py` — `active_domain_profile_name: str | None = None` field
- `src/ouroboros/auto/pipeline.py` — `_apply_active_profile()` helper + call site
- `tests/unit/auto/test_answerer_via_domain_profile.py` — 9 new tests

## Test plan

- [x] 622 unit tests pass (`tests/unit/auto/`) — 0 failures, 9 new tests added
- [x] `ruff check` + `ruff format --check` clean on all modified files
- [x] Broken test count: **0** (regular PR, not draft)

🤖 Generated with [Claude Code](https://claude.com/claude-code)